### PR TITLE
makes the features2 columns adjustable

### DIFF
--- a/src/components/widgets/Features2.astro
+++ b/src/components/widgets/Features2.astro
@@ -9,21 +9,25 @@ interface Item {
 
 export interface Props {
   title?: string;
+  columns?: number;
   subtitle?: string;
   highlight?: string;
   items: Array<Item>;
 }
 
 const {
+  columns,
   title = await Astro.slots.render('title'),
   subtitle = await Astro.slots.render('subtitle'),
   highlight,
   items = [],
 } = Astro.props;
+
+const totalColumns = columns || items.length;
 ---
 
 <section class="relative">
-  <div class="absolute inset-0 bg-blue-50 dark:bg-slate-800 pointer-events-none mb-32" aria-hidden="true"></div>
+  <div class="absolute inset-0 bg-amber-50 dark:bg-slate-800 pointer-events-none mb-32" aria-hidden="true"></div>
   <div class="relative max-w-7xl mx-auto px-4 sm:px-6 -mb-12">
     <div class="py-4 pt-8 sm:py-6 lg:py-8 lg:pt-12">
       {
@@ -48,7 +52,9 @@ const {
           </div>
         )
       }
-      <div class={`grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 my-12 dark:text-white items-stretch`}>
+      <div
+        class={`grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-${totalColumns} my-12 dark:text-white items-stretch`}
+      >
         {
           items.map(({ title, description, icon }) => (
             <div class="relative flex flex-col p-6 bg-white dark:bg-slate-900 rounded shadow-lg hover:shadow-md transition border border-transparent dark:border-slate-800">

--- a/src/config/pages/home/features2.js
+++ b/src/config/pages/home/features2.js
@@ -13,6 +13,9 @@ const features2 = {
   // Small highlight text at the top of the features2 section
   highlight: 'Components',
 
+  // total number of columns to display width wise
+  columns: 3,
+
   // The items in the features2 section
   items: [
     {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -134,6 +134,7 @@ const meta = {
   {
     features2 && features2.enabled && (
       <Features2
+        columns={features2.columns}
         title={features2.title}
         subtitle={features2.subtitle}
         highlight={features2.highlight}


### PR DESCRIPTION
This pull request adds a new `columns` option prop to the `features2` widget to make the column width adjustable