### PR TITLE
Fix build by removing astro-compress

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,6 @@ import sitemap from '@astrojs/sitemap';
 import image from '@astrojs/image';
 import mdx from '@astrojs/mdx';
 import partytown from '@astrojs/partytown';
-import compress from 'astro-compress';
 import { readingTimeRemarkPlugin } from './src/utils/frontmatter.mjs';
 import { SITE } from './src/config/site/config.js';
 import react from '@astrojs/react';
@@ -24,6 +23,7 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [readingTimeRemarkPlugin],
   },
+  compressHTML: true,
   integrations: [
     icon({
       include: {
@@ -50,16 +50,6 @@ export default defineConfig({
         },
       })
     ),
-    compress({
-      css: true,
-      html: {
-        removeAttributeQuotes: false,
-      },
-      img: false,
-      js: true,
-      svg: true,
-      logger: 1,
-    }),
     react(),
   ],
   vite: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.59.7",
         "astro": "^2.10.1",
-        "astro-compress": "^1.1.50",
         "astro-icon": "^1.0.0-next.2",
         "eslint": "^8.46.0",
         "eslint-plugin-astro": "^0.28.0",
@@ -1600,6 +1599,8 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2098,21 +2099,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-3m636Jz4d9d+lHVMp6FNLsUWQrfOx1xpm1SBxPbQYSNNgXMe+XswcsDeo1ldyULiuzYyWKk1kmvkLTgNq+215Q==",
-      "dev": true
-    },
-    "node_modules/@types/csso": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/csso/-/csso-5.0.0.tgz",
-      "integrity": "sha512-EMrCTGpXRUsbFfZBzn2jcW6Sqg8kxWXkJcpvAGYSEzFqAJ2THDJSwiMeS2fPUw+0p6RQNT/n8F/skEc9hUBc0g==",
-      "dev": true,
-      "dependencies": {
-        "@types/css-tree": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
@@ -2151,12 +2137,6 @@
       "dependencies": {
         "@types/unist": "^2"
       }
-    },
-    "node_modules/@types/html-minifier-terser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-7.0.0.tgz",
-      "integrity": "sha512-hw3bhStrg5e3FQT8qZKCJTrzt/UbEaunU1xRWJ+aNOTmeBMvE3S4Ml2HiiNnZgL8izu0LFVkHUoPFXL1s5QNpQ==",
-      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -3026,55 +3006,6 @@
         }
       }
     },
-    "node_modules/astro-compress": {
-      "version": "1.1.50",
-      "resolved": "https://registry.npmjs.org/astro-compress/-/astro-compress-1.1.50.tgz",
-      "integrity": "sha512-DsaDLpJT8yizuRfRoyTHGtS+NfPt/y+3z8QkdQFMSigV+apOHKWuTlC0hspMNW/6w+3WOWE8yO19RFoy2/fITQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/csso": "5.0.0",
-        "@types/html-minifier-terser": "7.0.0",
-        "csso": "5.0.5",
-        "files-pipe": "0.0.8",
-        "html-minifier-terser": "7.2.0",
-        "sharp": "0.32.4",
-        "svgo": "3.0.2",
-        "terser": "5.19.2"
-      }
-    },
-    "node_modules/astro-compress/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/astro-compress/node_modules/svgo": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-      "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.2.1",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
     "node_modules/astro-eslint-parser": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-0.14.0.tgz",
@@ -3564,7 +3495,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/bulk-replace": {
       "version": "0.0.1",
@@ -3618,16 +3551,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/camelcase": {
@@ -3830,27 +3753,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clean-css": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -3979,15 +3881,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/common-ancestor-path": {
@@ -4442,16 +4335,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/dset": {
@@ -5326,25 +5209,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/files-pipe": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/files-pipe/-/files-pipe-0.0.8.tgz",
-      "integrity": "sha512-c/hf3Kuhrlpn92sbe7HifJ4DOHrOPw7b7nR+4VIzqcuSXgkICwBicw6qDKoEjzEXCi6sjcL0CxBpYyikwf7KvQ==",
-      "dev": true,
-      "dependencies": {
-        "deepmerge-ts": "5.1.0",
-        "fast-glob": "3.3.1"
-      }
-    },
-    "node_modules/files-pipe/node_modules/deepmerge-ts": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
-      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6063,27 +5927,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "dev": true
-    },
-    "node_modules/html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/html-void-elements": {
       "version": "2.0.1",
@@ -7044,15 +6887,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/lru-cache": {
@@ -8437,16 +8271,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-abi": {
       "version": "3.45.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
@@ -8887,16 +8711,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8983,16 +8797,6 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -9812,15 +9616,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/remark-frontmatter": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
@@ -10578,6 +10373,8 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -10588,6 +10385,8 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11177,6 +10976,8 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
       "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -11194,7 +10995,9 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.59.7",
     "astro": "^2.10.1",
-    "astro-compress": "^1.1.50",
     "astro-icon": "^1.0.0-next.2",
     "eslint": "^8.46.0",
     "eslint-plugin-astro": "^0.28.0",


### PR DESCRIPTION
`astro-compress` has been deleted by the author, which has broken build a lot of sites & themes. Currently, I'm working through the themes affected by this.

This PR removes it as a dependency & enables [`compressHTML`](https://docs.astro.build/en/reference/configuration-reference/#compresshtml) which provides similar html minification to `astro-compress`.